### PR TITLE
fix: image version and license links

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 # This file is a template, and might need editing before it works on your project.
 # You can copy and paste this template into a new `.gitlab-ci.yml` file in your project.
 

--- a/Base.gitlab-ci.yml
+++ b/Base.gitlab-ci.yml
@@ -47,7 +47,7 @@
 
 # The default image is the one that contains the binary for our tool: https://github.com/hashicorp/tfc-workflows-tooling
 default:
-  image: hashicorp/tfci:latest
+  image: hashicorp/tfci:v1.0.0
 
 # Create and upload a configuration version to terraform-cloud.variables:
 # exported dotenv variables that can be referenced in later jobs:


### PR DESCRIPTION
Fix docker image to hashicorp/tfci:v1.0.0 and remove license from `.gitlab-ci.yml` file. This file is meant to be copied by users into their own projects.