### PR TITLE
fix: exclude gitlab ci yml from copywriting

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -7,5 +7,5 @@ project {
   # (OPTIONAL) A list of globs that should not have copyright/license headers.
   # Supports doublestar glob patterns for more flexibility in defining which
   # files or folders should be ignored
-  header_ignore = []
+  header_ignore = [".gitlab-ci.yml"]
 }


### PR DESCRIPTION
The `.gitlab-ci.yml` is not meant to be included in the `.copywrite.hcl` process. This file will be copy pasted by our customers into their own `.gitlab-ci.yml` files.