### PR TITLE
fix: remove needs keyword from comment_on_merge_request job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,6 @@ plan_output:
 comment_on_merge_request:
   stage: ".post"
   image: alpine/curl
-  needs: [ "plan_output" ]
   variables:
     MR_COMMENT: |
       Plan: ${add} to add, ${change} to change, ${destroy} to destroy.


### PR DESCRIPTION
The `run_link` variable does not resolve for the job `comment_on_merge_request` in [`.gitlab-ci.yml`](https://github.com/hashicorp/tfc-workflows-gitlab/blob/main/.gitlab-ci.yml#L89). Since, the resolution did not work, the comment ends up having an empty link for `run_link`.  This is how the curl request looks like with the empty link:

<img width="864" alt="image" src="https://github.com/hashicorp/tfc-workflows-gitlab/assets/44829199/ea555b84-11df-44b9-9f65-ecf49484bd49">

I think gitlab API implementation could be replacing the empty link with a link to the MR.

The `run_link` variable is missing because the Gitlab `needs` job keyword will only require artifacts from the jobs mentioned in the [`needs`](https://docs.gitlab.com/ee/ci/yaml/#needs) array. Since, the `comment_on_merge_request` job has a `needs` keyword, we are not able to import all the variables necessary for commenting. The `run_link` variable was exported by a job, `create_run` that was not mentioned in the `needs` keyword.

As per Gitlab [documentation](https://docs.gitlab.com/ee/ci/yaml/#needsartifacts):
> When a job uses needs, it no longer downloads all artifacts from previous stages by default, because jobs with needs can start before earlier stages complete. With needs you can only download artifacts from the jobs listed in the needs configuration.

As per this PR, we can remove the usage of `needs` keyword for this specific job. This will ensure all previously created variables are available for commenting.


