### PR TITLE
Prepare for v1.0.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@
 # The link to the remote base template. Note that the base template URL is versioned. Please check the base template for additional variables that need to be defined in GitLab.
 # Please subscribe to https://github.com/hashicorp/tfc-workflows-gitlab for updates.
 include:
-  remote: https://raw.githubusercontent.com/hashicorp/tfc-workflows-gitlab/v1.0.0/Base.gitlab-ci.yml
+  remote: https://raw.githubusercontent.com/hashicorp/tfc-workflows-gitlab/v1.0.2/Base.gitlab-ci.yml
 
 # Please refer: https://docs.gitlab.com/ee/ci/variables/
 # In order to use this template, the following CI/CD variables need to be defined in GitLab. The base remote template relies on these variables

--- a/Base.gitlab-ci.yml
+++ b/Base.gitlab-ci.yml
@@ -47,7 +47,7 @@
 
 # The default image is the one that contains the binary for our tool: https://github.com/hashicorp/tfc-workflows-tooling
 default:
-  image: hashicorp/tfci:v1.0.0
+  image: hashicorp/tfci:v1.0.2
 
 # Create and upload a configuration version to terraform-cloud.variables:
 # exported dotenv variables that can be referenced in later jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# UNRELEASED
+
+# v1.0.2
+* Bug fixes and enhancements from [tfc-workflows-tooling@v1.0.2](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.0.2) version bump
+
+# v1.0.0
+
+First Release


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/tfc-workflows-github! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Updates changelog and version pointers with information for `v1.0.2`, based off of the [tfc-workflows-tooling `v1.0.2` release](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.0.2).

## Versioning

This repository is not going to get a `v1.0.1` release. Users should upgrade from `v1.0.0` to `v1.0.2` as all changes are backwards compatible bug fixes.

Releases in this repository are intended to be kept in sync with both https://github.com/hashicorp/tfc-workflows-tooling, and https://github.com/hashicorp/tfc-workflows-github, which means that this release (`v1.0.2`) can not be named `v1.0.1` as it would cause confusion across the three repositories when discussing software versions.