### PR TITLE
docs: add release process doc

### DIFF
--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,3 @@
+## Release Process
+
+Refer to [hashicorp/tfc-workflows-tooling](https://github.com/hashicorp/tfc-workflows-tooling/blob/main/docs/RELEASES.md#gitlab-pipelines-release-process-hashicorptfc-workflows-gitlab) for release documentation for this project.


### PR DESCRIPTION
## Description

Adds Releases.md doc that references tfc-workflows-tooling release documentation.

## External links

- [Related PR](https://github.com/hashicorp/tfc-workflows-tooling/pull/86)
