### PR TITLE
Zainq11/testing plan only defaults

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,6 +46,8 @@ workflow:
         PROJECT_PIPELINE_NAME: "$CI_DEFAULT_BRANCH pipeline"
         PLAN_ONLY: "false"
         SPECULATIVE: "false"
+        SAVE_PLAN: "false"
+        IS_DESTROY: "false"
     # Workflows on merge requests only do a plan run.
     # Alternatively, you could trigger a plan run on any push, if: $CI_PIPELINE_SOURCE == "push"
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -54,6 +56,8 @@ workflow:
         PROJECT_PIPELINE_NAME: "Merge Request pipeline: $CI_MERGE_REQUEST_SOURCE_BRANCH_NAME"
         PLAN_ONLY: "true"
         SPECULATIVE: "true"
+        SAVE_PLAN: "false"
+        IS_DESTROY: "false"
 
 upload_configuration:
   stage: ".pre"

--- a/Base.gitlab-ci.yml
+++ b/Base.gitlab-ci.yml
@@ -69,9 +69,9 @@ default:
   variables:
     CONFIGURATION_VERSION_ID: $configuration_version_id
     MESSAGE: "Base template message. Override this"
-    PLAN_ONLY: false
-    SAVE_PLAN: false
-    IS_DESTROY: false
+    PLAN_ONLY: "false"
+    SAVE_PLAN: "false"
+    IS_DESTROY: "false"
   script:
     - tfci -hostname=$TF_CLOUD_HOSTNAME  -token=$TF_API_TOKEN -organization=$TF_CLOUD_ORGANIZATION run create -workspace=$TF_WORKSPACE -configuration_version=$CONFIGURATION_VERSION_ID -message=$MESSAGE -plan-only=$PLAN_ONLY -save-plan=$SAVE_PLAN -is-destroy=$IS_DESTROY
   artifacts:

--- a/Base.gitlab-ci.yml
+++ b/Base.gitlab-ci.yml
@@ -69,6 +69,9 @@ default:
   variables:
     CONFIGURATION_VERSION_ID: $configuration_version_id
     MESSAGE: "Base template message. Override this"
+    PLAN_ONLY: false
+    SAVE_PLAN: false
+    IS_DESTROY: false
   script:
     - tfci -hostname=$TF_CLOUD_HOSTNAME  -token=$TF_API_TOKEN -organization=$TF_CLOUD_ORGANIZATION run create -workspace=$TF_WORKSPACE -configuration_version=$CONFIGURATION_VERSION_ID -message=$MESSAGE -plan-only=$PLAN_ONLY -save-plan=$SAVE_PLAN -is-destroy=$IS_DESTROY
   artifacts:

--- a/Base.gitlab-ci.yml
+++ b/Base.gitlab-ci.yml
@@ -69,9 +69,6 @@ default:
   variables:
     CONFIGURATION_VERSION_ID: $configuration_version_id
     MESSAGE: "Base template message. Override this"
-    PLAN_ONLY: "false"
-    SAVE_PLAN: "false"
-    IS_DESTROY: "false"
   script:
     - tfci -hostname=$TF_CLOUD_HOSTNAME  -token=$TF_API_TOKEN -organization=$TF_CLOUD_ORGANIZATION run create -workspace=$TF_WORKSPACE -configuration_version=$CONFIGURATION_VERSION_ID -message=$MESSAGE -plan-only=$PLAN_ONLY -save-plan=$SAVE_PLAN -is-destroy=$IS_DESTROY
   artifacts:


### PR DESCRIPTION
Defaults for boolean vars `SAVE_PLAN` & `IS_DESTROY`

Need defaults for the binary to work:
```
$ tfci -hostname=$TF_CLOUD_HOSTNAME  -token=$TF_API_TOKEN -organization=$TF_CLOUD_ORGANIZATION run create -workspace=$TF_WORKSPACE -configuration_version=$CONFIGURATION_VERSION_ID -message=$MESSAGE -plan-only=$PLAN_ONLY -save-plan=$SAVE_PLAN -is-destroy=$IS_DESTROY
error parsing command-line flags: invalid boolean value "" for -save-plan: parse error
```
