### PR TITLE
Prepare v1.3.1 release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@
 # The link to the remote base template. Note that the base template URL is versioned. Please check the base template for additional variables that need to be defined in GitLab.
 # Please subscribe to https://github.com/hashicorp/tfc-workflows-gitlab for updates.
 include:
-  remote: https://raw.githubusercontent.com/hashicorp/tfc-workflows-gitlab/v1.3.0/Base.gitlab-ci.yml
+  remote: https://raw.githubusercontent.com/hashicorp/tfc-workflows-gitlab/v1.3.1/Base.gitlab-ci.yml
 
 # Please refer: https://docs.gitlab.com/ee/ci/variables/
 # In order to use this template, the following CI/CD variables need to be defined in GitLab. The base remote template relies on these variables

--- a/Base.gitlab-ci.yml
+++ b/Base.gitlab-ci.yml
@@ -47,7 +47,7 @@
 
 # The default image is the one that contains the binary for our tool: https://github.com/hashicorp/tfc-workflows-tooling
 default:
-  image: hashicorp/tfci:v1.3.0
+  image: hashicorp/tfci:v1.3.1
 
 # Create and upload a configuration version to terraform-cloud.variables:
 # exported dotenv variables that can be referenced in later jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # UNRELEASED
 
+# v1.3.1
+* Fixes message argument to correctly handle multi string values by @Rohlik [#26](https://github.com/hashicorp/tfc-workflows-gitlab/pull/26)
+* Bug fixes and enhancements from [tfc-workflows-tooling@v1.3.1](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.3.1)
+* Compiles for Linux regardless of current CPU architecture when using the provided Dockerfile by @ggambetti [hashicorp/tfc-workflows-tooling#113](https://github.com/hashicorp/tfc-workflows-tooling/pull/113)
+
 # v1.3.0
 * Adds support for `target` input for `create-run` action by @trutled3 [#97](https://github.com/hashicorp/tfc-workflows-tooling/pull/97)
 * Bug fixes and enhancements from [tfc-workflows-tooling@v1.3.0](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.3.0)


### PR DESCRIPTION
## Description

Preparing for `v1.3.1` release. See links below

## External links

[TFCI v1.3.1 Release](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.3.1)
