### PR TITLE
prepare v1.3.2 release

### DIFF
--- a/Base.gitlab-ci.yml
+++ b/Base.gitlab-ci.yml
@@ -47,7 +47,7 @@
 
 # The default image is the one that contains the binary for our tool: https://github.com/hashicorp/tfc-workflows-tooling
 default:
-  image: hashicorp/tfci:v1.3.1
+  image: hashicorp/tfci:v1.3.2
 
 # Create and upload a configuration version to terraform-cloud.variables:
 # exported dotenv variables that can be referenced in later jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # UNRELEASED
 
+# v1.3.2
+* Bug fixes and enhancements from [tfc-workflows-tooling@v1.3.2](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.3.2) version bump
+
 # v1.3.1
 * Fixes message argument to correctly handle multi string values by @Rohlik [#26](https://github.com/hashicorp/tfc-workflows-gitlab/pull/26)
 * Bug fixes and enhancements from [tfc-workflows-tooling@v1.3.1](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.3.1)


### PR DESCRIPTION
Prepares v1.3.2 release

- [Related PR](https://github.com/hashicorp/tfc-workflows-tooling/releases/tag/v1.3.2)